### PR TITLE
Fix array to scalar bug in estraiAIF function (DSC_mri_aif.m)

### DIFF
--- a/utils/DSC_mri_aif.m
+++ b/utils/DSC_mri_aif.m
@@ -196,7 +196,7 @@ end
 ROI=ROI.*maschera; % Dei voxel della ROI mantengo solo quelli presenti anche nella maschera
 ROIiniziale=ROI;
 
-xROI=centro(1)-semiasseB:0.01:centro+semiasseB;
+xROI=centro(1)-semiasseB:0.01:centro(1)+semiasseB;
 nL=length(xROI);
 xROI(2*nL)=0;
 yROI=zeros(1,2*nL);


### PR DESCRIPTION
Hi, 

When running `DSC_main_demo.m`, the script threw an error at line 199 in `utils/DSC_mri_aif.m`: "Colon operands must be real scalars."

The variable `centro` is an array, so I added the missing index `(1)` to `centro` on the right side of the colon operator to ensure both operands are scalars.

Changed:
`xROI=centro(1)-semiasseB:0.01:centro+semiasseB;`
To:
`xROI=centro(1)-semiasseB:0.01:centro(1)+semiasseB;`

This fixes the bug and allows the AIF extraction to run successfully.